### PR TITLE
Basic register dump works

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -9,8 +9,6 @@ unsafe extern "C" fn kmain() -> ! {
 
     init();
 
-    panic!("Kernel panic test");
-
     hlt_loop();
 }
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -9,11 +9,15 @@ unsafe extern "C" fn kmain() -> ! {
 
     init();
 
+    panic!("Kernel panic test");
+
     hlt_loop();
 }
 
 #[panic_handler]
 fn rust_panic(info: &core::panic::PanicInfo) -> ! {
-    panic_log!("{}", info);
+    use hexium_os::utils::registers::*;
+    panic_log!("{}\n", info);
+    print_register_dump(&get_registers());
     hlt_loop();
 }

--- a/kernel/src/utils/mod.rs
+++ b/kernel/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod registers;
 pub mod types;
 
 pub fn octal_to_binrary(s: &[u8]) -> i32 {

--- a/kernel/src/utils/registers.rs
+++ b/kernel/src/utils/registers.rs
@@ -1,5 +1,4 @@
 use core::arch::asm;
-use core::fmt;
 
 /// Returns the registers of the CPU in a struct
 pub fn get_registers() -> Registers {
@@ -9,13 +8,14 @@ pub fn get_registers() -> Registers {
     let (r12, r13, r14, r15): (u64, u64, u64, u64);
     let rip: u64;
     let rflags: u64;
+    let (cs, ds, es, fs, gs, ss): (u16, u16, u16, u16, u16, u16);
 
     unsafe {
         // First group
         asm!(
             "mov {0}, rax",
             "mov {1}, rbx",
-            "mov {2}, rcx", 
+            "mov {2}, rcx",
             "mov {3}, rdx",
             out(reg) rax,
             out(reg) rbx,
@@ -77,6 +77,23 @@ pub fn get_registers() -> Registers {
             out(reg) rflags,
             options(nomem),
         );
+
+        // Segment Registers
+        asm!(
+            "mov {0:x}, cs",
+            "mov {1:x}, ds", 
+            "mov {2:x}, es",
+            "mov {3:x}, fs",
+            "mov {4:x}, gs",
+            "mov {5:x}, ss",
+            out(reg) cs,
+            out(reg) ds,
+            out(reg) es,
+            out(reg) fs,
+            out(reg) gs,
+            out(reg) ss,
+            options(nomem, nostack),
+        );
     }
 
     Registers {
@@ -98,59 +115,93 @@ pub fn get_registers() -> Registers {
         r14,
         r15,
         rflags,
+        cs,
+        ds,
+        es,
+        fs,
+        gs,
+        ss,
     }
 }
-
-/// Struct to hold the register values.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Registers {
-    rax: u64,
-    rbx: u64,
-    rcx: u64,
-    rdx: u64,
-    rsi: u64,
-    rdi: u64,
-    rsp: u64,
-    rbp: u64,
-    rip: u64,
-    r8: u64,
-    r9: u64,
-    r10: u64,
-    r11: u64,
-    r12: u64,
-    r13: u64,
-    r14: u64,
-    r15: u64,
-    rflags: u64,
+    // General Purpose
+    pub rax: u64,
+    pub rbx: u64,
+    pub rcx: u64,
+    pub rdx: u64,
+    pub rsi: u64,
+    pub rdi: u64,
+    pub rbp: u64,
+    pub rsp: u64,
+    pub r8: u64,
+    pub r9: u64,
+    pub r10: u64,
+    pub r11: u64,
+    pub r12: u64,
+    pub r13: u64,
+    pub r14: u64,
+    pub r15: u64,
+
+    // Control Registers
+    pub rip: u64,
+    pub rflags: u64,
+
+    // Segment Registers
+    pub cs: u16,
+    pub ds: u16,
+    pub es: u16,
+    pub fs: u16,
+    pub gs: u16,
+    pub ss: u16,
 }
 
-/// Display trait to format the Registers struct nicely.
-impl fmt::Display for Registers {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "Registers:")?;
-        writeln!(f, "  rax: {:016x}", self.rax)?;
-        writeln!(f, "  rbx: {:016x}", self.rbx)?;
-        writeln!(f, "  rcx: {:016x}", self.rcx)?;
-        writeln!(f, "  rdx: {:016x}", self.rdx)?;
-        writeln!(f, "  rsi: {:016x}", self.rsi)?;
-        writeln!(f, "  rdi: {:016x}", self.rdi)?;
-        writeln!(f, "  rsp: {:016x}", self.rsp)?;
-        writeln!(f, "  rbp: {:016x}", self.rbp)?;
-        writeln!(f, "  rip: {:016x}", self.rip)?;
-        writeln!(f, "  r8:  {:016x}", self.r8)?;
-        writeln!(f, "  r9:  {:016x}", self.r9)?;
-        writeln!(f, "  r10: {:016x}", self.r10)?;
-        writeln!(f, "  r11: {:016x}", self.r11)?;
-        writeln!(f, "  r12: {:016x}", self.r12)?;
-        writeln!(f, "  r13: {:016x}", self.r13)?;
-        writeln!(f, "  r14: {:016x}", self.r14)?;
-        writeln!(f, "  r15: {:016x}", self.r15)?;
-        writeln!(f, "  rflags: {:016x}", self.rflags)?;
-        Ok(())
-    }
+// Helper macros for formatting
+macro_rules! print_pair {
+    ($left:expr, $left_val:expr, $right:expr, $right_val:expr) => {
+        println!(
+            "│ {:.<4} 0x{:016x} │ {:.<4} 0x{:016x} │",
+            $left, $left_val, $right, $right_val
+        );
+    };
 }
 
-/// Function to print the register dump.
-pub fn print_register_dump(registers: &Registers) {
-    crate::print!("{}\n", registers);
+macro_rules! print_segment_pair {
+    ($left:expr, $left_val:expr, $right:expr, $right_val:expr) => {
+        println!(
+            "│ {:<4} 0x{:04x}             │ {:<4} 0x{:04x}             │",
+            $left, $left_val, $right, $right_val
+        );
+    };
+}
+
+pub fn print_register_dump(regs: &Registers) {
+    use crate::println;
+    println!("\nRegister Dump:");
+    println!("┌─────────────────────────┬─────────────────────────┐");
+
+    // General Purpose Registers
+    print_pair!("rax", regs.rax, "rbx", regs.rbx);
+    print_pair!("rcx", regs.rcx, "rdx", regs.rdx);
+    print_pair!("rsi", regs.rsi, "rdi", regs.rdi);
+    print_pair!("rbp", regs.rbp, "rsp", regs.rsp);
+    print_pair!("r8 ", regs.r8, "r9 ", regs.r9);
+    print_pair!("r10", regs.r10, "r11", regs.r11);
+    print_pair!("r12", regs.r12, "r13", regs.r13);
+    print_pair!("r14", regs.r14, "r15", regs.r15);
+
+    println!("├─────────────────────────┴─────────────────────────┤");
+
+    // Control Registers
+    println!("│ {: <30} 0x{:016x} │", "rip:", regs.rip);
+    println!("│ {: <30} 0x{:016x} │", "rflags:", regs.rflags);
+
+    println!("├─────────────────────────┬─────────────────────────┤");
+
+    // Segment Registers
+    print_segment_pair!("cs", regs.cs, "ds", regs.ds);
+    print_segment_pair!("es", regs.es, "fs", regs.fs);
+    print_segment_pair!("gs", regs.gs, "ss", regs.ss);
+
+    println!("└─────────────────────────┴─────────────────────────┘");
 }

--- a/kernel/src/utils/registers.rs
+++ b/kernel/src/utils/registers.rs
@@ -1,0 +1,156 @@
+use core::arch::asm;
+use core::fmt;
+
+/// Returns the registers of the CPU in a struct
+pub fn get_registers() -> Registers {
+    let (rax, rbx, rcx, rdx): (u64, u64, u64, u64);
+    let (rsi, rdi, rsp, rbp): (u64, u64, u64, u64);
+    let (r8, r9, r10, r11): (u64, u64, u64, u64);
+    let (r12, r13, r14, r15): (u64, u64, u64, u64);
+    let rip: u64;
+    let rflags: u64;
+
+    unsafe {
+        // First group
+        asm!(
+            "mov {0}, rax",
+            "mov {1}, rbx",
+            "mov {2}, rcx", 
+            "mov {3}, rdx",
+            out(reg) rax,
+            out(reg) rbx,
+            out(reg) rcx,
+            out(reg) rdx,
+            options(nomem, nostack),
+        );
+
+        // Second group
+        asm!(
+            "mov {0}, rsi",
+            "mov {1}, rdi",
+            "mov {2}, rsp",
+            "mov {3}, rbp",
+            out(reg) rsi,
+            out(reg) rdi,
+            out(reg) rsp,
+            out(reg) rbp,
+            options(nomem, nostack),
+        );
+
+        // Third group
+        asm!(
+            "mov {0}, r8",
+            "mov {1}, r9",
+            "mov {2}, r10",
+            "mov {3}, r11",
+            out(reg) r8,
+            out(reg) r9,
+            out(reg) r10,
+            out(reg) r11,
+            options(nomem, nostack),
+        );
+
+        // Fourth group
+        asm!(
+            "mov {0}, r12",
+            "mov {1}, r13",
+            "mov {2}, r14",
+            "mov {3}, r15",
+            out(reg) r12,
+            out(reg) r13,
+            out(reg) r14,
+            out(reg) r15,
+            options(nomem, nostack),
+        );
+
+        // RIP (instruction pointer)
+        asm!(
+            "lea {0}, [rip]",
+            out(reg) rip,
+            options(nomem, nostack),
+        );
+
+        // RFLAGS
+        asm!(
+            "pushfq",
+            "pop {0}",
+            out(reg) rflags,
+            options(nomem),
+        );
+    }
+
+    Registers {
+        rax,
+        rbx,
+        rcx,
+        rdx,
+        rsi,
+        rdi,
+        rsp,
+        rbp,
+        rip,
+        r8,
+        r9,
+        r10,
+        r11,
+        r12,
+        r13,
+        r14,
+        r15,
+        rflags,
+    }
+}
+
+/// Struct to hold the register values.
+#[derive(Debug)]
+pub struct Registers {
+    rax: u64,
+    rbx: u64,
+    rcx: u64,
+    rdx: u64,
+    rsi: u64,
+    rdi: u64,
+    rsp: u64,
+    rbp: u64,
+    rip: u64,
+    r8: u64,
+    r9: u64,
+    r10: u64,
+    r11: u64,
+    r12: u64,
+    r13: u64,
+    r14: u64,
+    r15: u64,
+    rflags: u64,
+}
+
+/// Display trait to format the Registers struct nicely.
+impl fmt::Display for Registers {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Registers:")?;
+        writeln!(f, "  rax: {:016x}", self.rax)?;
+        writeln!(f, "  rbx: {:016x}", self.rbx)?;
+        writeln!(f, "  rcx: {:016x}", self.rcx)?;
+        writeln!(f, "  rdx: {:016x}", self.rdx)?;
+        writeln!(f, "  rsi: {:016x}", self.rsi)?;
+        writeln!(f, "  rdi: {:016x}", self.rdi)?;
+        writeln!(f, "  rsp: {:016x}", self.rsp)?;
+        writeln!(f, "  rbp: {:016x}", self.rbp)?;
+        writeln!(f, "  rip: {:016x}", self.rip)?;
+        writeln!(f, "  r8:  {:016x}", self.r8)?;
+        writeln!(f, "  r9:  {:016x}", self.r9)?;
+        writeln!(f, "  r10: {:016x}", self.r10)?;
+        writeln!(f, "  r11: {:016x}", self.r11)?;
+        writeln!(f, "  r12: {:016x}", self.r12)?;
+        writeln!(f, "  r13: {:016x}", self.r13)?;
+        writeln!(f, "  r14: {:016x}", self.r14)?;
+        writeln!(f, "  r15: {:016x}", self.r15)?;
+        writeln!(f, "  rflags: {:016x}", self.rflags)?;
+        Ok(())
+    }
+}
+
+/// Function to print the register dump.
+pub fn print_register_dump(registers: &Registers) {
+    crate::print!("{}\n", registers);
+}

--- a/kernel/src/writer.rs
+++ b/kernel/src/writer.rs
@@ -93,7 +93,7 @@ macro_rules! print {
 #[macro_export]
 macro_rules! println {
     () => (print!("\n"));
-    ($($arg:tt)*) => (print!("{}\n", format_args!($($arg)*)));
+    ($($arg:tt)*) => (crate::print!("{}\n", format_args!($($arg)*)));
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
Created a basic nicely formatted register dump which gets print on panic:
```
┌─────────────────────────┬─────────────────────────┐
│ rax. 0xffff80007e683ed8 │ rbx. 0x0000000000000000 │
│ rcx. 0x0000000000000000 │ rdx. 0x0000000000000000 │
│ rsi. 0xffff80007e683ed8 │ rdi. 0xffff80007e683ed8 │
│ rbp. 0x0000000000000000 │ rsp. 0xffff80007e683cb0 │
│ r8 . 0x0000000000000000 │ r9 . 0x0000000000000001 │
│ r10. 0xffff80007e682ed8 │ r11. 0x0000000000000020 │
│ r12. 0x0000000000000000 │ r13. 0x0000000000000000 │
│ r14. 0x0000000000000000 │ r15. 0x0000000000000000 │
├─────────────────────────┴─────────────────────────┤
│ rip:                           0xffffffff80000491 │
│ rflags:                        0x0000000000000282 │
├─────────────────────────┬─────────────────────────┤
│ cs   0x0008             │ ds   0x0030             │
│ es   0x0030             │ fs   0x0030             │
│ gs   0x0030             │ ss   0x0010             │
└─────────────────────────┴─────────────────────────┘
```